### PR TITLE
Add -fno-lto and -lavdevice to allow build on ArchLinux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -230,6 +230,7 @@
             '-lLabSound',
             '-lavformat',
             '-lavcodec',
+            '-lavdevice',
             '-lavutil',
             '-lswscale',
             '-lswresample',
@@ -238,6 +239,7 @@
           ],
           'ldflags': [
             '-Wl,-Bsymbolic',
+            '-fno-lto',
             '-Wl,-rpath,./node_modules/native-graphics-deps/lib/linux/glew',
             '-Wl,-rpath,./node_modules/native-graphics-deps/lib/linux/glfw',
             '-Wl,-rpath,./node_modules/native-canvas-deps/lib/linux',


### PR DESCRIPTION
Blindly implemented solution from here: https://github.com/halide/Halide/issues/2713 for -fno-lto and it builds now.
Added -lavdevice when exokit would build but not start.

Now fully builds with:
npm: 6.0.0-next.1
node: v10.0.0-nightly20180416978e1524bb
gcc: 7.3.1 20180312